### PR TITLE
Address bad karma opts

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ingesolvoll/doo "0.2.0"
+(defproject ingesolvoll/doo "0.2.1"
   :description "doo is a library to run clj.test on different js environments."
   :url "https://github.com/bensu/doo"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :scm {:name "git"
-        :url "https://github.com/bensu/doo"
+        :url "https://github.com/ingesolvoll/doo"
         :dir ".."}
 
   :deploy-repositories [["clojars" {:sign-releases false

--- a/src/doo/core.clj
+++ b/src/doo/core.clj
@@ -305,7 +305,8 @@ where:
    {:pre [(valid-js-env? js-env (karma/custom-launchers opts))]}
    (let [doo-opts (merge default-opts opts)
          cmd (cond-> (js->command js-env compiler-opts doo-opts)
-               (not (self-hosted? js-env)) (conj (or (:output-to doo-opts) (:output-to compiler-opts))))]
+               (and (not (self-hosted? js-env)) (not (karma/env? js-env compiler-opts)))
+               (conj (or (:output-to doo-opts) (:output-to compiler-opts))))]
      (when (:debug doo-opts)
        (utils/debug-log "Command to run script:" cmd))
      (try


### PR DESCRIPTION
Starting with [Karma v6](https://github.com/karma-runner/karma/blob/master/CHANGELOG.md#breaking-changes):

> Karma is more strict and will error out if unknown option or argument is passed to CLI.

It turns out that doo has been passing bad opts to karma, but karma just used to grin and take it. No longer.

This change adds a check to see if doo has been asked to target karma, and if so, only passes config.
Doo was formerly passing config and compiled JavaScript to karma, karma does not expect compiled JavaScript.

Change tested with Karma v5 and v6 in rewrite-clj which uses cljs-test-runner (and hence this fork of doo) to target node, chrome-headless (via karma) and planck.

I tried running unit test for doo via `lein test` but it appears they are in a broken state?